### PR TITLE
Update egui and readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_blur_regions"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Andrew Bentley <andrew@bentley.codes>"]
 edition = "2021"
 description = "A Bevy plugin to selectively blur regions of the screen"
@@ -8,8 +8,10 @@ repository = "https://github.com/atbentley/bevy_blur_regions"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = ["bevy_render"] }
-bevy_egui = { version = "0.31", optional = true }
+bevy = { version = "0.15", default-features = false, features = [
+    "bevy_render",
+] }
+bevy_egui = { version = "0.32", optional = true }
 
 [features]
 all = ["bevy_ui", "egui"]

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ fn main() {
 }
 ```
 
-Add the `BlurRegionsCamera` component to the 3D camera whose output should be blurred:
+Add the `BlurRegionsCamera` component to the camera whose output should be blurred:
 
 ```rust
 commands.spawn((
     BlurRegionsCamera::default(),
-    Camera3dBundle::default(),
+    Camera3d::default(), // or Camera2d
 ));
 ```
 
@@ -54,10 +54,9 @@ When using egui, enable the `egui` feature and then use the `show_with_blur` fun
 ```rust
 fn draw_ui(
     mut contexts: EguiContexts,
-{
+) {
     let frame = egui::Frame::window(&contexts.ctx_mut().style())
         .fill(egui::Color32::from_rgba_premultiplied(27, 27, 27, 100))
-        .rounding(0.0)
         .shadow(egui::epaint::Shadow::NONE);
 
     egui::Window::new("Blurry Window")
@@ -91,6 +90,7 @@ The number of blur regions that can be present on the screen at the same time is
 
 | bevy_blur_regions | bevy | bevy_egui |
 |-------------------|------|-----------|
+| 0.6.0             | 0.15 | 0.32      |
 | 0.5.0             | 0.14 | 0.30      |
 | 0.4.0             | 0.14 | 0.28      |
 | 0.3.0             | 0.14 | 0.28      |


### PR DESCRIPTION
Egui 0.32, and readme now shows you can use Camera2d, and it also stops using the deprecated Bevy Bundles for Camera, and it also removes the setting rounding to 0 on egui, to show we can have rounded egui window blur

Also bumped crate version and added to Compatibility table